### PR TITLE
Configure branch name in config file

### DIFF
--- a/GitAutoDeploy.conf.json.example
+++ b/GitAutoDeploy.conf.json.example
@@ -8,6 +8,7 @@
 	"repositories":
 	[{
 		"url": "https://github.com/logsol/Test-Repo",
+		"branch": "master",
 		"path": "/home/logsol/projects/Test-Repo",
 		"deploy": "echo deploying"
 	},

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -45,10 +45,10 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
 
 	def do_process(self, urls):
 		for url in urls:
-			paths = self.getMatchingPaths(url)
-			for path in paths:
-				self.pull(path)
-				self.deploy(path)
+			repos = self.getMatchingPaths(url)
+			for repo in repos:
+				self.pull(repo['path'], repo['branch'])
+				self.deploy(repo['path'])
 
 	def parseRequest(self):
 		contenttype = self.headers.getheader('content-type')
@@ -100,7 +100,10 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
 		config = self.getConfig()
 		for repository in config['repositories']:
 			if(repository['url'] == repoUrl):
-				res.append(repository['path'])
+				res.append({
+					'path': repository['path'],
+					'branch': (repository['branch'] or 'master')
+				})
 		return res
 
 	def respond(self):
@@ -108,11 +111,11 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
 		self.send_header('Content-type', 'text/plain')
 		self.end_headers()
 
-	def pull(self, path):
+	def pull(self, path, branch):
 		if(not self.quiet):
 			print "\nPost push request received"
 			print 'Updating ' + path
-		call(['cd "' + path + '" && git fetch origin ; git update-index --refresh &> /dev/null ; git reset --hard origin/master'], shell=True)
+		call(['cd "' + path + '" && git fetch origin ; git update-index --refresh &> /dev/null ; git reset --hard origin/' + branch], shell=True)
 
 	def deploy(self, path):
 		config = self.getConfig()

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -102,7 +102,7 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
 			if(repository['url'] == repoUrl):
 				res.append({
 					'path': repository['path'],
-					'branch': (repository['branch'] or 'master')
+					'branch': ('branch' in repository) and repository['branch'] or 'master'
 				})
 		return res
 


### PR DESCRIPTION
Hi.

I made it using branch name from config. If there is no branch in config or it's empty it uses 'master'
Use case: I need to auto deploy different branches of the same repository.

Regards, Sergei.