### PR TITLE
Dockerfile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM google/python-runtime
+
+RUN apt-get -y install openssh-client
+RUN mkdir $HOME/.ssh && chmod 700 $HOME/.ssh
+COPY deploy_rsa /root/.ssh/id_rsa
+
+ENTRYPOINT ["/env/bin/python", "-u", "GitAutoDeploy.py", "--ssh-keyscan"]


### PR DESCRIPTION
Supporting a docker container requires fetching the ssh keys of repositories,
so a new option --ssh-keyscan was added.  This option tries to create a
/root/.ssh/authorized_keys based on the configured repositories.