### PR TITLE
Make HTTP server listen only on localhost by default; Add config opti…

### DIFF
--- a/GitAutoDeploy.conf.json.example
+++ b/GitAutoDeploy.conf.json.example
@@ -1,5 +1,6 @@
 {
 	"pidfilepath": "/var/run/gitautodeploy/gitautodeploy.pid",
+	"host": "localhost",
 	"port": 8001,
 	"global_deploy": [
 		"echo Starting deploy!",

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -199,7 +199,9 @@ class GitAutoDeployMain:
 			print 'Github & Gitlab Autodeploy Service v 0.1 started in daemon mode'
 
 		try:
-			self.server = HTTPServer(('', GitAutoDeploy.getConfig()['port']), GitAutoDeploy)
+			self.server = HTTPServer((GitAutoDeploy.getConfig()['host'], GitAutoDeploy.getConfig()['port']), GitAutoDeploy)
+			sa = self.server.socket.getsockname()
+			print "Listeing on", sa[0], "port", sa[1]
 			self.server.serve_forever()
 		except socket.error, e:
 			if(not GitAutoDeploy.quiet and not GitAutoDeploy.daemon):


### PR DESCRIPTION
By default the HTTP server listens for web hooks on all known interfaces. This might be an unnecessary security risk as this way the HTTP server also accepts request from outside instead of just accepting request from the local host.

Using only localhost as default is completely acceptable for GitLab web-hooks, but requires an extra configuration step for GitHub (set `"host":"",` in the config file), since the hooks have to be reachable from the outside. However, I think it's better to have a secure setup by default and allowing more insecure setups only through extra configuration.

If localhost as default might not be acceptable for you, you should at least consider to add the `host` config option, to allow GitLab users to restrict the listen interfaces of the HTTP server.