### PR TITLE
Fix for locked repo bug & submodule support 

### DIFF
--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -31,7 +31,7 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
 			for repository in myClass.config['repositories']:
 				if(not os.path.isdir(repository['path'])):
 					print "Directory %s not found" % repository['path']
-					call(['git clone '+repository['url']+' '+repository['path']], shell=True)
+					call(['git clone --recursive '+repository['url']+' '+repository['path']], shell=True)
 					if(not os.path.isdir(repository['path'])):
 						print "Unable to clone repository %s" % repository['url']
 						sys.exit(2)
@@ -140,7 +140,7 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
 		if(not self.quiet):
 			print "\nPost push request received"
 			print 'Updating ' + path
-		res = call(['sleep 5; cd "' + path + '" && unset GIT_DIR && git fetch origin && git update-index --refresh && git reset --hard origin/' + branch], shell=True)
+		res = call(['sleep 5; cd "' + path + '" && unset GIT_DIR && git fetch origin && git update-index --refresh && git reset --hard origin/' + branch + ' && git submodule init && git submodule update'], shell=True)
 		call(['echo "Pull result: ' + str(res) + '"'], shell=True)
 		return res
 

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -140,7 +140,7 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
 		if(not self.quiet):
 			print "\nPost push request received"
 			print 'Updating ' + path
-		res = call(['sleep 5; cd "' + path + '" && git fetch origin ; git update-index --refresh &> /dev/null ; git reset --hard origin/' + branch], shell=True)
+		res = call(['sleep 5; cd "' + path + '" && unset GIT_DIR && git fetch origin && git update-index --refresh && git reset --hard origin/' + branch], shell=True)
 		call(['echo "Pull result: ' + str(res) + '"'], shell=True)
 		return res
 


### PR DESCRIPTION
The current master caused an "existing index.lock file" error (forgot the exact message) when I tried to use it as a web-hook in GitLab. I was able to fix this by changing the deploy command a bit in commit 5c4d7a7. The new version is a bit more verbose, but follows the suggestions made at http://gitolite.com/deploy.html#fetch----reverse-the-flow.

Apart from that I recognized that the current master does not deploy any submodules, which might be part of the repo. Therefore I added the appropriate commands to the clone and deploy command lines in commit f40eaa8. The `git submodule ...` calls do nothing if all submodules are up-to-date or if no submodules exist. 